### PR TITLE
vxrd: fix state location in VXLAN regexp

### DIFF
--- a/vxfld/cmd/vxrd.py
+++ b/vxfld/cmd/vxrd.py
@@ -219,7 +219,7 @@ class _Vxrd(service.Vxfld):
     """
     __VXLAN_REGEX = re.compile(
         r'^\d+: (?P<dev_name>\S+):'
-        r'(?=.*state\s+(?P<state>\S+))'
+        r'(?=.*?state\s+(?P<state>\S+))'
         r'(?=.*vxlan\s+id\s+(?P<vni>\d+))'
         r'(?=.*dstport\s+(?P<dstport>\d+))?'
         r'(?=.*local\s+(?P<local_addr>{0}))?'


### PR DESCRIPTION
When parsing "ip link" output, the "state" keyword can appear twice:

    6: vxlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br0 state UNKNOWN mode DEFAULT group default qlen 1000
        link/ether ea:4c:04:8e:98:06 brd ff:ff:ff:ff:ff:ff promiscuity 1
        vxlan id 100 local 203.0.113.1 srcport 0 0 dstport 4789 ttl 5 ageing 300 udpcsum noudp6zerocsumtx noudp6zerocsumrx
        bridge_slave state forwarding priority 32 cost 100 hairpin off guard off root_block off fastleave off learning on flood on port_id 0x8002 port_no 0x2 designated_port 32770 designated_cost 0 designated_bridge 8000.50:54:33:0:0:2 designated_root 8000.50:54:33:0:0:2 hold_timer    0.00 message_age_timer    0.00 forward_delay_timer    0.00 topology_change_ack 0 config_pending 0 proxy_arp off proxy_arp_wifi off mcast_router 1 mcast_fast_leave off mcast_flood on addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535

This is with iproute 4.9. Fix the regex to only keep the first
occurrence.